### PR TITLE
SafeAreaViewに関するテストを追加

### DIFF
--- a/__tests__/App-test.tsx
+++ b/__tests__/App-test.tsx
@@ -14,6 +14,10 @@ it('renders correctly', () => {
   expect(_safeAreaViewColor()).toBe(Colors.lighter);
 });
 
+it('renders correctly with dark', () => {
+  expect(_safeAreaViewColor()).toBe(Colors.darker);
+});
+
 function _safeAreaViewColor() {
   const app = renderer.create(<App />);
   const safeAreaView = app.root.findByType(SafeAreaView);

--- a/__tests__/App-test.tsx
+++ b/__tests__/App-test.tsx
@@ -2,13 +2,20 @@
  * @format
  */
 
-import 'react-native';
 import React from 'react';
-import App from 'src/App';
-
+import {SafeAreaView} from 'react-native';
+import {Colors} from 'react-native/Libraries/NewAppScreen';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
+import App from 'src/App';
+
 it('renders correctly', () => {
-  renderer.create(<App />);
+  expect(_safeAreaViewColor()).toBe(Colors.lighter);
 });
+
+function _safeAreaViewColor() {
+  const app = renderer.create(<App />);
+  const safeAreaView = app.root.findByType(SafeAreaView);
+  return safeAreaView.props.style.backgroundColor;
+}


### PR DESCRIPTION
以下記事を参考に `useColorScheme` をmockしようとするも、上手くいかなかったためクローズ。

- https://www.appsloveworld.com/react-native/100/131/mock-react-native-appearance-locally-with-jest
- https://stackoverflow.com/questions/72450113/react-native-jest-mock-usecolorscheme
- https://github.com/facebook/react-native/issues/28839